### PR TITLE
Make deploy on Heroku work by fixing dependencies and use of http-proxy-middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,9 @@
     "@babel/polyfill": "^7.2.5",
     "body-parser": "^1.18.3",
     "ejs": "^2.6.1",
-    "express": "^4.16.4"
+    "express": "^4.16.4",
+	"request": "^2.88.0",
+    "tslib": "^1.9.3"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",
@@ -116,7 +118,6 @@
     "style-loader": "^0.23.1",
     "ts-jest": "^23.10.5",
     "tsc-watch": "^1.0.31",
-    "tslib": "^1.9.3",
     "tslint": "^5.12.1",
     "typescript": "^3.2.2",
     "url-loader": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "body-parser": "^1.18.3",
     "ejs": "^2.6.1",
     "express": "^4.16.4",
-	"request": "^2.88.0",
+    "request": "^2.88.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "body-parser": "^1.18.3",
     "ejs": "^2.6.1",
     "express": "^4.16.4",
-    "request": "^2.88.0",
     "tslib": "^1.9.3"
   },
   "devDependencies": {
@@ -114,6 +113,7 @@
     "react-hot-loader": "^4.6.3",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
+    "request": "^2.88.0",
     "rimraf": "^2.6.3",
     "style-loader": "^0.23.1",
     "ts-jest": "^23.10.5",

--- a/src/server/routes/manifest-manager.ts
+++ b/src/server/routes/manifest-manager.ts
@@ -1,10 +1,10 @@
 import { IS_PRODUCTION, WEBPACK_PORT } from '../config';
-import * as request from 'request';
 import * as fs from 'fs';
 import * as path from 'path';
 
 function getManifestFromWebpack(): Promise<any> {
   return new Promise((resolve, reject) => {
+    const request = require("request");
     request.get(`http://localhost:${WEBPACK_PORT}/statics/manifest.json`, {}, (err, data) => {
       if (err) {
         reject(err);

--- a/src/server/routes/statics-router.ts
+++ b/src/server/routes/statics-router.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as express from 'express';
 import { Router } from 'express';
-import * as proxy from 'http-proxy-middleware';
 import * as config from '../config';
 
 export function staticsRouter() {
@@ -13,6 +12,7 @@ export function staticsRouter() {
     // All the assets are in "statics" folder (Done by Webpack during the build phase)
     router.use('/statics', express.static(staticsPath));
   } else {
+    const proxy = require('http-proxy-middleware');
     // All the assets are hosted by Webpack on localhost:${config.WEBPACK_PORT} (Webpack-dev-server)
     router.use(
       '/statics',


### PR DESCRIPTION
This fixes the problem I encountered in https://github.com/gilamran/fullstack-typescript/issues/19.

From what I understand, Heroku uses devDependencies only while building and then prunes them. That means that while running we didn't have tslib (because it is a devDepenceny) and request (because it is not mentioned in the depencies at all and is likely a depency of another devDependency). Additionally, importing http-proxy-middleware via import meant that it was required even when staticsRouter wasn't using it.

I fixed those problems by adding tslib and request to the production dependencies and by getting http-proxy-middleware via ```require()``` only when needed.