### PR TITLE
Sets VSCode to use TypeScript version from project

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}


### PR DESCRIPTION
I was getting error `option 'noEmit' cannot be specified with option 'composite'` because VSCode is using `TypeScript 3.8.3` but project needs `Typescript 3.9.2`